### PR TITLE
[WIP] [designspaceLib] designspace docs edits (#1750)

### DIFF
--- a/Lib/fontTools/designspaceLib/__init__.py
+++ b/Lib/fontTools/designspaceLib/__init__.py
@@ -182,7 +182,7 @@ def evaluateConditions(conditions, location):
 
 
 def processRules(rules, location, glyphNames):
-    """ Apply these rules at this location to these glyphnames.minimum
+    """ Apply these rules at this location to these glyphnames
         - rule order matters
     """
     newNames = []


### PR DESCRIPTION
Various changes in the designspaceLib readme.rst
- added docs for DesignSpaceDocument object, methods and attributes
- removed comments on validation, localisation and generating UFO instances.
- added note that axis minimum, default and maximum are in userspace coordinates.
- added clarification to map input (userpace!) / output (designspace!) values.
- added note that sourceDescriptor location is in designspace coordinates.
- moved comment on rule subs to rule descriptor object.
- added proposed "processing" flag to rules element
- move note on sub element
- implementation differences
- varlib vs. mutatormath
- older versions
- rules and generating static ufo instances
- Updated the description of the `copyInfo` flag of the sourceDescriptor.
- Change the example import.
- Remove additional mention of copyInfo.