### PR TITLE
[COLR] should set self.version after decompiling COLRv1

### DIFF
--- a/Lib/fontTools/ttLib/tables/C_O_L_R_.py
+++ b/Lib/fontTools/ttLib/tables/C_O_L_R_.py
@@ -66,6 +66,7 @@ class table_C_O_L_R_(DefaultTable.DefaultTable):
 		else:
 			# for new versions, keep the raw otTables around
 			self.table = table
+			self.version = table.Version
 
 	def compile(self, ttFont):
 		from .otBase import OTTableWriter


### PR DESCRIPTION
we set self.version for COLRv0 already; makes easier to check COLR.version